### PR TITLE
Create CONTRIBUTING.md link to our guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing Guidelines
+
+We love improvements to our tools! EDGI has general [guidelines for contributing](https://github.com/edgi-govdata-archiving/overview/blob/master/CONTRIBUTING.md) to all of our organizational repos. 
+
+Thank you for your help!


### PR DESCRIPTION
Addresses https://github.com/edgi-govdata-archiving/overview/issues/26

We are trying to link people back to our (currently nascent) contributing guidelines and keep that documentation in one place.